### PR TITLE
Exclude duplicate doc from uploading by Admin

### DIFF
--- a/backend/tests/test_pdf_upload.py
+++ b/backend/tests/test_pdf_upload.py
@@ -56,3 +56,58 @@ def test_upload_pdf_valid(client, app):
     # Check the JSON message
         assert upload_response.status_code == 200
         assert response_data["message"] == "File 'test.pdf' uploaded successfully!"
+
+
+def test_upload_pdf_dup(client, app):
+    app.config['WTF_CSRF_ENABLED'] = False
+    
+
+    with app.app_context():
+        client = login_user(client)
+        # Path to the test file inside the test_data folder
+        file_path = os.path.join(os.path.dirname(__file__), 'test_data', 'Dna.pdf')
+
+        # Open the file in binary read mode
+        with open(file_path, 'rb') as f:
+            # Create a FileStorage object from the file content
+            pdf_file = FileStorage(
+                stream=io.BytesIO(f.read()),
+                filename="Dna.pdf",
+                content_type="application/pdf",
+            )
+
+        # Prepare the data dictionary with the file for upload
+        data = {
+            "pdf_file": (io.BytesIO(pdf_file.read()), "Dna.pdf"),
+        }
+
+        # Make the POST request to the upload route First time
+        upload_response = client.post("/upload", data=data, follow_redirects=True)
+
+        # Open the file again in binary read mode
+        with open(file_path, 'rb') as f2:
+            # Create a FileStorage object from the file content
+            pdf_file2 = FileStorage(
+                stream=io.BytesIO(f2.read()),
+                filename="Dna.pdf",
+                content_type="application/pdf",
+            )
+        
+        # Prepare the data dictionary with the file for upload
+        data = {
+            "pdf_file": (io.BytesIO(pdf_file2.read()), "Dna.pdf"),
+        }
+        
+    
+        # Make the POST request to the upload route Second time
+        upload_response_2 = client.post("/upload", data=data, follow_redirects=True)
+
+    # Get the JSON response using get_json()
+        response_data = upload_response_2.get_json()
+    
+    # Ensure the response data is not None before accessing
+        assert response_data is not None  # Ensure the response is valid JSON
+    
+    # Check the JSON message
+        assert upload_response_2.status_code == 409
+        assert response_data["error"] == "A document named 'Dna.pdf' already exists."


### PR DESCRIPTION
Somebody already finish this. I tested it on main and then on chat.bscb.site and it was already there.  


I just made a test for it. I test my test in Docker Desktop backend
My test upload a file 2 times, and the second time it will return error saying "A document named Dna.pdf already exists"